### PR TITLE
DayNight Telephony Theming (6/7)

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -15,7 +15,7 @@
 -->
 
 <resources>
-    <style name="Theme.Telecomm.Transparent" parent="@android:style/Theme.Material.Light">
+    <style name="Theme.Telecomm.Transparent" parent="@android:style/Theme.Material.DayNight">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -25,7 +25,7 @@
         <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
     </style>
 
-    <style name="Theme.Telecom.DialerSettings" parent="@android:style/Theme.Material.Light">
+    <style name="Theme.Telecom.DialerSettings" parent="@android:style/Theme.Material.DayNight">
         <item name="android:actionBarStyle">@style/TelecomDialerSettingsActionBarStyle</item>
         <item name="android:actionOverflowButtonStyle">@style/TelecomDialerSettingsActionOverflowButtonStyle</item>
         <item name="android:colorPrimaryDark">@color/dialer_settings_color_dark</item>


### PR DESCRIPTION
* Changes required for DayNight theming of all Telephony related things (Contacts/Dialer/InCallUI) can be found at the following locations:
1. Contacts
2. ContactsCoommon
3. Dialer
4. InCallUI
5. PhoneCommon
6. Services_Telecomm
7. Services_Telephony

Notes for Developers:
* There are no drawable changes whatsoever.  This relies only on on hex color edits.
* Because there are no drawable changes difficult areas to theme dark (ie searchbar) remain white.  A white searchbar looks classy in my opinion and everything below searchbar is material dark.
* Changes should not interfere with Layers themes in Day mode and most likely will not interfere much in night mode either (although I assume most themes were geared for day mode anyways)
* I've kept all values from values/colors.xml in values-night/colors.xml for easy file comparison if you'd like to change some things around. If that bugs you, feel free to remove them.
* Feedback/suggestions are always welcome.

Change-Id: Ie9d857ed52f56a480662c09d8a98696800a8eabe